### PR TITLE
fix: reject id: null requests per MCP spec §4.2.1 (workaround for python-sdk#2057)

### DIFF
--- a/server.py
+++ b/server.py
@@ -24,6 +24,7 @@ from src.prompts import register_prompts
 
 # Import middleware
 from src.middleware import register_middleware
+from src.middleware.null_id_validation import NullIdValidationMiddleware
 
 # Import custom routes
 from src.routes.routes import register_custom_routes
@@ -136,6 +137,27 @@ register_custom_routes(app)
 # Start background tasks that require event loop
 from src.middleware.middleware import start_background_tasks
 start_background_tasks()
+
+
+def _wrap_http_app_with_null_id_validation():
+    """Ensure NullIdValidationMiddleware is applied for all HTTP deployments.
+
+    FastMCP Cloud/Horizon calls app.http_app() directly (ignores __main__),
+    so we wrap it to always include the null-id validation middleware.
+    """
+    from starlette.middleware import Middleware
+
+    _original_http_app = app.http_app
+
+    def _http_app(**kwargs):
+        middleware = list(kwargs.get("middleware") or [])
+        middleware.insert(0, Middleware(NullIdValidationMiddleware))
+        return _original_http_app(middleware=middleware, **kwargs)
+
+    app.http_app = _http_app
+
+
+_wrap_http_app_with_null_id_validation()
 
 if __name__ == "__main__":
     if ENVIRONMENT == "production":

--- a/src/middleware/null_id_validation.py
+++ b/src/middleware/null_id_validation.py
@@ -1,0 +1,96 @@
+"""
+Null ID validation middleware for MCP JSON-RPC compliance.
+
+Workaround for MCP Python SDK issue #2057:
+https://github.com/modelcontextprotocol/python-sdk/issues/2057
+
+When a JSON-RPC request arrives with "id": null, the SDK incorrectly
+classifies it as a notification and returns 202 with no response.
+Per MCP spec §4.2.1 and JSON-RPC 2.0, request IDs must be strings or
+numbers - null must be rejected with an error.
+
+This HTTP-level middleware validates the raw request body BEFORE it
+reaches the MCP SDK, rejecting malformed requests with a proper
+JSON-RPC error response.
+"""
+
+import json
+import logging
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger("null_id_validation")
+
+
+def _has_null_id(data: dict) -> bool:
+    """Check if JSON-RPC message has id: null (invalid per MCP spec)."""
+    return (
+        isinstance(data, dict)
+        and data.get("jsonrpc") == "2.0"
+        and "method" in data
+        and "id" in data
+        and data["id"] is None
+    )
+
+
+def _json_rpc_error_response(request_id: None, code: int, message: str) -> dict:
+    """Build JSON-RPC 2.0 error response."""
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {
+            "code": code,
+            "message": message,
+            "data": "Request id must be a string or number, not null. "
+            "See MCP spec §4.2.1 and https://github.com/modelcontextprotocol/python-sdk/issues/2057",
+        },
+    }
+
+
+class NullIdValidationMiddleware(BaseHTTPMiddleware):
+    """
+    Rejects JSON-RPC requests with id: null before they reach the MCP SDK.
+
+    Per MCP 2025-11-25 §4.2.1: Request identifiers must be strings or
+    numbers. Requests with id: null must be rejected with an error.
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if request.method != "POST":
+            return await call_next(request)
+
+        try:
+            body = await request.body()
+        except Exception as e:
+            logger.warning("NullIdValidation: could not read body: %s", e)
+            return await call_next(request)
+
+        if not body:
+            return await call_next(request)
+
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            return await call_next(request)
+
+        if not _has_null_id(data):
+            # Valid - pass through; re-inject body for downstream
+            async def receive():
+                return {"type": "http.request", "body": body, "more_body": False}
+
+            request = Request(request.scope, receive=receive)
+            return await call_next(request)
+
+        # Reject with JSON-RPC Invalid Request
+        logger.warning("Rejected JSON-RPC request with id: null (method=%s)", data.get("method"))
+        return JSONResponse(
+            status_code=400,
+            content=_json_rpc_error_response(
+                request_id=None,
+                code=-32600,
+                message="Invalid Request",
+            ),
+        )

--- a/tests/test_null_id_validation.py
+++ b/tests/test_null_id_validation.py
@@ -1,0 +1,79 @@
+"""
+Tests for NullIdValidationMiddleware.
+
+Validates MCP spec §4.2.1 compliance: requests with id: null must be rejected.
+Workaround for https://github.com/modelcontextprotocol/python-sdk/issues/2057
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+
+def test_has_null_id_helper():
+    """Unit test for _has_null_id detection logic."""
+    from src.middleware.null_id_validation import _has_null_id
+
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": None}) is True
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": "x"}) is False
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": 1}) is False
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init"}) is False  # notification
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": 0}) is False
+
+
+@pytest.fixture
+def http_client():
+    """Create test client with HTTP app (includes NullIdValidationMiddleware)."""
+    from server import app
+
+    asgi_app = app.http_app(path="/mcp/")
+    return TestClient(asgi_app)
+
+
+def test_rejects_null_id_request(http_client):
+    """Requests with id: null must be rejected with 400 and JSON-RPC error."""
+    response = http_client.post(
+        "/mcp/",
+        json={"jsonrpc": "2.0", "method": "initialize", "id": None},
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+    data = response.json()
+    assert data["jsonrpc"] == "2.0"
+    assert data["id"] is None
+    assert "error" in data
+    assert data["error"]["code"] == -32600
+    assert "Invalid Request" in data["error"]["message"]
+    assert "null" in data["error"].get("data", "").lower()
+
+
+def test_allows_valid_request_id_string(http_client):
+    """Requests with string id should pass through (may get other MCP response)."""
+    response = http_client.post(
+        "/mcp/",
+        json={"jsonrpc": "2.0", "method": "initialize", "id": "test-123"},
+        headers={"Content-Type": "application/json"},
+    )
+    # Should not be 400 from our middleware (could be 200 or other MCP response)
+    assert response.status_code != 400 or "Invalid Request" not in str(response.content)
+
+
+def test_allows_notification_without_id(http_client):
+    """Notifications (no id field) should pass through."""
+    response = http_client.post(
+        "/mcp/",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Content-Type": "application/json"},
+    )
+    # Notifications don't have id - should pass through
+    assert response.status_code != 400 or "Invalid Request" not in str(response.content)
+
+
+def test_has_null_id_helper():
+    """Unit test for _has_null_id detection logic."""
+    from src.middleware.null_id_validation import _has_null_id
+
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": None}) is True
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": "x"}) is False
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": 1}) is False
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init"}) is False  # notification
+    assert _has_null_id({"jsonrpc": "2.0", "method": "init", "id": 0}) is False


### PR DESCRIPTION
## Summary
Rejects JSON-RPC requests with `id: null` at the HTTP layer before they reach the MCP SDK.

## Problem
Caused by upstream bug in MCP Python SDK: [modelcontextprotocol/python-sdk#2057](https://github.com/modelcontextprotocol/python-sdk/issues/2057). Requests with `"id": null` are misclassified as notifications and return 202 instead of being rejected.

## Solution
- Added `NullIdValidationMiddleware` to validate raw HTTP body before SDK parsing
- Returns 400 with proper JSON-RPC error per MCP spec §4.2.1
- AuthProbe should now pass this check

Closes #5

Made with [Cursor](https://cursor.com)