### PR TITLE
feat: add Tavily as optional parallel search engine alongside DuckDuckGo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pypdf>=6.6.0",
     "python-docx>=1.2.0",
     "easyocr>=1.7.2",
+    "tavily-python>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ cryptography==46.0.3
     # via
     #   authlib
     #   pyjwt
+    #   secretstorage
 cyclopts==4.5.0
     # via fastmcp
 diskcache==5.6.3
@@ -95,6 +96,7 @@ httpx==0.28.1
     #   fastmcp
     #   mcp
     #   openrouter
+    #   tavily-python
 httpx-sse==0.4.3
     # via mcp
 idna==3.11
@@ -116,6 +118,10 @@ jaraco-context==6.1.0
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via torch
 jsonschema==4.26.0
@@ -290,11 +296,15 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
+regex==2026.2.28
+    # via tiktoken
 requests==2.32.5
     # via
     #   rivalsearchmcp (pyproject.toml)
     #   jsonschema-path
     #   pytrends
+    #   tavily-python
+    #   tiktoken
 rich==14.2.0
     # via
     #   cyclopts
@@ -314,6 +324,8 @@ scipy==1.17.0
     # via
     #   easyocr
     #   scikit-image
+secretstorage==3.5.0
+    # via keyring
 sgmllib3k==1.0.0
     # via feedparser
 shapely==2.1.2
@@ -334,8 +346,12 @@ starlette==0.52.1
     #   sse-starlette
 sympy==1.14.0
     # via torch
+tavily-python==0.7.23
+    # via rivalsearchmcp (pyproject.toml)
 tifffile==2026.1.14
     # via scikit-image
+tiktoken==0.12.0
+    # via tavily-python
 torch==2.9.1
     # via
     #   easyocr

--- a/src/core/search/engines/tavily/__init__.py
+++ b/src/core/search/engines/tavily/__init__.py
@@ -1,0 +1,7 @@
+"""
+Tavily search engine package.
+"""
+
+from .tavily_engine import TavilySearchEngine
+
+__all__ = ["TavilySearchEngine"]

--- a/src/core/search/engines/tavily/tavily_engine.py
+++ b/src/core/search/engines/tavily/tavily_engine.py
@@ -66,5 +66,5 @@ class TavilySearchEngine(BaseSearchEngine):
             return []
 
     async def close(self):
-        """Close the engine. Tavily client has no persistent session to close."""
-        pass
+        """Close the engine and inherited httpx session."""
+        await super().close()

--- a/src/core/search/engines/tavily/tavily_engine.py
+++ b/src/core/search/engines/tavily/tavily_engine.py
@@ -1,0 +1,70 @@
+"""
+Tavily search engine implementation for RivalSearchMCP.
+Uses the Tavily API for high-quality web search results.
+Requires TAVILY_API_KEY environment variable to be set.
+"""
+
+from datetime import datetime
+from typing import List
+
+from tavily import AsyncTavilyClient
+
+from src.logging.logger import logger
+
+from ...core.multi_engines import BaseSearchEngine, MultiSearchResult
+
+
+class TavilySearchEngine(BaseSearchEngine):
+    """Tavily search engine implementation using the tavily-python SDK."""
+
+    def __init__(self, api_key: str):
+        super().__init__("Tavily", "https://api.tavily.com")
+        self.client = AsyncTavilyClient(api_key=api_key)
+
+    async def search(
+        self,
+        query: str,
+        num_results: int = 10,
+        extract_content: bool = True,
+        follow_links: bool = True,
+        max_depth: int = 2,
+    ) -> List[MultiSearchResult]:
+        """Search using the Tavily API and map results to MultiSearchResult."""
+        try:
+            logger.info(f"Starting Tavily search for: {query}")
+
+            search_depth = "advanced" if extract_content else "basic"
+
+            response = await self.client.search(
+                query=query,
+                max_results=min(num_results, 20),
+                search_depth=search_depth,
+                include_answer=False,
+            )
+
+            results: List[MultiSearchResult] = []
+            tavily_results = response.get("results", [])
+
+            for i, item in enumerate(tavily_results):
+                result = MultiSearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    description=item.get("content", ""),
+                    engine="tavily",
+                    position=i + 1,
+                    timestamp=datetime.now().isoformat(),
+                    real_url=item.get("url", ""),
+                    full_content=item.get("raw_content") if extract_content else None,
+                )
+                results.append(result)
+
+            logger.info(f"Tavily search returned {len(results)} results")
+            return results
+
+        except Exception as e:
+            logger.error(f"Tavily search failed: {e}")
+            return []
+
+    async def close(self):
+        """Close the engine. Tavily client has no persistent session to close."""
+        pass

--- a/src/tools/multi_search.py
+++ b/src/tools/multi_search.py
@@ -4,6 +4,7 @@ Provides comprehensive search across multiple engines with fallback support.
 """
 
 import asyncio
+import os
 from datetime import datetime
 from typing import Any, Dict
 
@@ -24,6 +25,17 @@ class MultiSearchOrchestrator:
             "wikipedia": WikipediaSearchEngine(),
         }
         self.engine_order = ["duckduckgo", "wikipedia"]
+
+        # Conditionally add Tavily engine when API key is available
+        tavily_api_key = os.environ.get("TAVILY_API_KEY")
+        if tavily_api_key:
+            from src.core.search.engines.tavily.tavily_engine import TavilySearchEngine
+
+            self.engines["tavily"] = TavilySearchEngine(api_key=tavily_api_key)
+            self.engine_order.append("tavily")
+            logger.info("Tavily search engine enabled")
+        else:
+            logger.debug("TAVILY_API_KEY not set; Tavily engine disabled")
 
     async def search_all_engines(
         self,

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,6 +1,6 @@
 """
 Search tools for FastMCP server.
-Handles multi-engine search with Yahoo and DuckDuckGo engines.
+Handles multi-engine search with DuckDuckGo, Wikipedia, and optional Tavily engines.
 """
 
 from typing import Annotated
@@ -59,7 +59,7 @@ def register_search_tools(mcp: FastMCP):
         ] = True,
     ) -> str:
         """
-        Multi-engine search across Yahoo and DuckDuckGo with enhanced security validation.
+        Multi-engine search across DuckDuckGo, Wikipedia, and optional Tavily with enhanced security validation.
 
         This tool searches across multiple engines simultaneously with:
         - Input validation and sanitization

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -18,12 +18,13 @@ def register_search_tools(mcp: FastMCP):
 
     @mcp.tool(
         name="web_search",
-        description="Search across Yahoo and DuckDuckGo engines with fallback support",
-        tags={"search", "web", "yahoo", "duckduckgo"},
+        description="Search across DuckDuckGo and Wikipedia engines with fallback support. "
+        "Optionally includes Tavily when TAVILY_API_KEY is set.",
+        tags={"search", "web", "duckduckgo", "wikipedia", "tavily"},
         meta={
-            "version": "1.0",
+            "version": "1.1",
             "category": "Search",
-            "engines": ["yahoo", "duckduckgo"],
+            "engines": ["duckduckgo", "wikipedia", "tavily (optional)"],
         },
         annotations={
             "title": "Web Search",

--- a/tests/tools/test_tavily_engine.py
+++ b/tests/tools/test_tavily_engine.py
@@ -1,0 +1,156 @@
+"""
+Tests for TavilySearchEngine and Tavily integration in MultiSearchOrchestrator.
+Uses unittest.mock to avoid requiring a real Tavily API key.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import pytest
+
+from src.core.search.engines.tavily.tavily_engine import TavilySearchEngine
+
+
+@pytest.mark.asyncio
+async def test_search_maps_results_to_multi_search_result():
+    """Successful search maps Tavily results to MultiSearchResult correctly."""
+    mock_response = {
+        "results": [
+            {
+                "title": "Python Tutorial",
+                "url": "https://example.com/python",
+                "content": "Learn Python programming.",
+                "raw_content": "Full article about Python programming.",
+            },
+            {
+                "title": "Async Python",
+                "url": "https://example.com/async",
+                "content": "Async programming in Python.",
+                "raw_content": None,
+            },
+        ]
+    }
+
+    with patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        MockClient.return_value = mock_client
+
+        engine = TavilySearchEngine(api_key="test-key")
+        results = await engine.search("Python programming", num_results=5, extract_content=True)
+
+    assert len(results) == 2
+
+    assert results[0].title == "Python Tutorial"
+    assert results[0].url == "https://example.com/python"
+    assert results[0].description == "Learn Python programming."
+    assert results[0].engine == "tavily"
+    assert results[0].position == 1
+    assert results[0].real_url == "https://example.com/python"
+    assert results[0].full_content == "Full article about Python programming."
+
+    assert results[1].title == "Async Python"
+    assert results[1].position == 2
+    assert results[1].full_content is None
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_api_error():
+    """search() returns [] on API error without raising."""
+    with patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(side_effect=Exception("API rate limit exceeded"))
+        MockClient.return_value = mock_client
+
+        engine = TavilySearchEngine(api_key="test-key")
+        results = await engine.search("test query")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_uses_basic_depth_when_extract_content_false():
+    """search_depth is 'basic' when extract_content=False."""
+    mock_response = {"results": []}
+
+    with patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        MockClient.return_value = mock_client
+
+        engine = TavilySearchEngine(api_key="test-key")
+        await engine.search("test", extract_content=False)
+
+    mock_client.search.assert_called_once()
+    call_kwargs = mock_client.search.call_args[1]
+    assert call_kwargs["search_depth"] == "basic"
+
+
+@pytest.mark.asyncio
+async def test_search_uses_advanced_depth_when_extract_content_true():
+    """search_depth is 'advanced' when extract_content=True."""
+    mock_response = {"results": []}
+
+    with patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient:
+        mock_client = AsyncMock()
+        mock_client.search = AsyncMock(return_value=mock_response)
+        MockClient.return_value = mock_client
+
+        engine = TavilySearchEngine(api_key="test-key")
+        await engine.search("test", extract_content=True)
+
+    call_kwargs = mock_client.search.call_args[1]
+    assert call_kwargs["search_depth"] == "advanced"
+
+
+@pytest.mark.asyncio
+async def test_close_calls_super_close():
+    """close() properly cleans up the inherited httpx session."""
+    with patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient:
+        MockClient.return_value = AsyncMock()
+        engine = TavilySearchEngine(api_key="test-key")
+
+    # The engine inherits an httpx.AsyncClient as self.session from BaseSearchEngine
+    engine.session = AsyncMock()
+    engine.session.aclose = AsyncMock()
+
+    await engine.close()
+
+    engine.session.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_includes_tavily_when_key_set():
+    """MultiSearchOrchestrator includes Tavily in engines when TAVILY_API_KEY is set."""
+    with (
+        patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test-key"}),
+        patch("src.core.search.engines.tavily.tavily_engine.AsyncTavilyClient") as MockClient,
+    ):
+        MockClient.return_value = AsyncMock()
+
+        from src.tools.multi_search import MultiSearchOrchestrator
+
+        orchestrator = MultiSearchOrchestrator()
+
+    assert "tavily" in orchestrator.engines
+    assert "tavily" in orchestrator.engine_order
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_skips_tavily_when_key_absent():
+    """MultiSearchOrchestrator excludes Tavily when TAVILY_API_KEY is not set."""
+    env = os.environ.copy()
+    env.pop("TAVILY_API_KEY", None)
+
+    with patch.dict(os.environ, env, clear=True):
+        from src.tools.multi_search import MultiSearchOrchestrator
+
+        orchestrator = MultiSearchOrchestrator()
+
+    assert "tavily" not in orchestrator.engines
+    assert "tavily" not in orchestrator.engine_order


### PR DESCRIPTION
## Summary
- Added Tavily as a configurable, optional search engine that runs in parallel with DuckDuckGo and Wikipedia
- When `TAVILY_API_KEY` is set, Tavily results are automatically merged and deduplicated with existing engines
- When the key is absent, behavior is unchanged — fully backward compatible

## Files changed
- **`src/core/search/engines/tavily/__init__.py`** (new) — Package init exporting `TavilySearchEngine`
- **`src/core/search/engines/tavily/tavily_engine.py`** (new) — `TavilySearchEngine` implementing `BaseSearchEngine.search()` using `AsyncTavilyClient`, mapping Tavily results to `MultiSearchResult`
- **`src/tools/multi_search.py`** — Conditionally adds `TavilySearchEngine` to `MultiSearchOrchestrator.engines` when `TAVILY_API_KEY` env var is present
- **`src/tools/search.py`** — Updated tool description, tags, and meta to document Tavily as an optional engine
- **`pyproject.toml`** — Added `tavily-python>=0.3.0` to project dependencies

## Dependency changes
- Added `tavily-python>=0.3.0` to `pyproject.toml` `[project].dependencies`

## Environment variable changes
- `TAVILY_API_KEY` (optional) — enables Tavily engine when set; server works without it

## Notes for reviewers
- Existing deduplication-by-URL logic in `search_all_engines()` handles merging Tavily results without further changes
- The Tavily import is deferred (inside `__init__`) so it only triggers when the API key is present
- Uses `search_depth="advanced"` when `extract_content=True` for higher relevance results

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily migration is well-implemented and correctly addresses all 5 issues from the previous review. The engine follows the existing BaseSearchEngine contract, uses AsyncTavilyClient correctly, maps Tavily response fields accurately to MultiSearchResult, and cleanly integrates as an optional parallel engine gated on TAVILY_API_KEY. The close() fix properly delegates to super().close() which calls session.aclose(). Both pyproject.toml and requirements.txt are updated, and 7 unit tests cover the key scenarios. Only minor issues remain (unused imports in test file, TAVILY_API_KEY missing from CLAUDE.md's env-var documentation section, and Linux-specific transitive deps in requirements.txt from platform-specific regeneration), none of which block approval.
