### PR TITLE
ci: add Claude Code workflows for PR review and @claude mentions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,46 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for the RivalSearchMCP project. Focus on:
+
+            1. **Correctness** — bugs, broken control flow, incorrect MCP tool
+               schemas or return shapes, regressions in existing tool behavior.
+            2. **Python quality** — type hints, error handling at boundaries,
+               idiomatic use of async/await, fastmcp conventions.
+            3. **Security** — input validation on URLs and user-supplied
+               queries, no secret leakage, safe handling of fetched HTML.
+            4. **Testing** — pytest coverage for new code paths; verify
+               existing tests still cover changed behavior.
+            5. **Docs** — README/CLAUDE.md/AGENTS.md updates when public
+               tool surface or setup changes.
+
+            Use inline comments for specific issues and a top-level comment
+            for the overall summary. Be direct and concrete; cite file:line
+            when pointing things out. Skip nitpicks if the change is small.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code-review.yml` — auto-runs a Claude review on every PR (opened / synchronize / reopened / ready_for_review) with a RivalSearchMCP-tailored prompt (correctness, Python quality, security, tests, docs).
- Adds `.github/workflows/claude.yml` — responds to `@claude` mentions in issues, PR comments, and reviews so Claude can answer questions and **draft code changes / open PRs** on demand.
- Both workflows use the official `anthropics/claude-code-action@v1`.

## What you need to do as repo admin
This PR adds the workflow files, but it won't actually do anything until you complete two admin-only steps:

1. **Install the Claude GitHub App** on this repo: https://github.com/apps/claude
2. **Add `ANTHROPIC_API_KEY`** under *Settings → Secrets and variables → Actions → New repository secret*. Get a key at https://console.anthropic.com.

The fastest path is to run `/install-github-app` from inside Claude Code (the CLI) while authenticated as a repo admin — it walks you through both steps interactively.

After those two steps, merging this PR enables:
- **Auto-review on every PR** — Claude posts inline comments + a summary.
- **`@claude` in any issue / PR / comment** — Claude responds, and can draft code changes as a PR.

## Test plan
- [ ] Install the Claude GitHub App on the repo.
- [ ] Add `ANTHROPIC_API_KEY` as a repository secret.
- [ ] Merge this PR.
- [ ] Open a trivial test PR and confirm `Claude Code Review` runs and posts a review comment.
- [ ] Open an issue with `@claude` in the body and confirm `Claude Code` runs and responds.

## Notes
- I don't have push/admin on this repo, so I can't install the app or add the secret myself — only the workflow files come from this PR.
- The `pull_request` trigger on `claude-code-review.yml` runs against the PR head with no secrets exposed to forked PRs by default (GitHub default behavior), so the workflow safely no-ops on PRs from forks where it can't read `ANTHROPIC_API_KEY`. For first-party PRs from this repo's branches, it'll have full access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)