### PR TITLE
Add Claude Code GitHub Workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+


### PR DESCRIPTION
<div align="center">

# 🤖 Claude Code GitHub Integration

[![Powered by Claude](https://img.shields.io/badge/Powered_by-Claude-D97757?style=flat-square&logo=anthropic&logoColor=white)](https://claude.com/claude-code) [![Claude Code Action](https://img.shields.io/badge/anthropics-claude--code--action%40v1-2D2D2D?style=flat-square&logo=github&logoColor=white)](https://github.com/anthropics/claude-code-action) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](https://opensource.org/licenses/MIT) [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/) [![FastMCP](https://img.shields.io/badge/FastMCP-3.2.4-4B8BBE?style=flat-square)](https://github.com/jlowin/fastmcp) [![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-Enabled-2088FF?style=flat-square&logo=githubactions&logoColor=white)](https://github.com/features/actions)

</div>

---

## Overview

This PR installs the [Claude Code GitHub App](https://github.com/apps/claude) on the repository and adds two GitHub Actions workflows that bring Claude into the dev loop:

| Workflow | Trigger | What it does |
|---|---|---|
| `claude.yml` | `@claude` mentions in issues, PR comments, PR reviews | Claude answers questions and drafts code changes / PRs on demand |
| `claude-code-review.yml` | Every PR (`opened` / `synchronize` / `reopened` / `ready_for_review`) | Claude posts an inline + summary review of the diff |

## What is Claude Code?

[Claude Code](https://claude.com/claude-code) is Anthropic's AI coding agent. In a GitHub Actions context it can:

- 🐛 Diagnose bugs and propose fixes
- 📝 Update documentation alongside code changes
- ✨ Implement small-to-medium features end-to-end
- 🔍 Review pull requests with inline comments
- 🧪 Write or improve tests
- ♻️ Refactor and modernize code

## How it works

Once this PR is merged, anyone with write access can interact with Claude by:

```text
@claude please add a unit test for the URL validator in src/...
```

…anywhere comments are allowed (issues, PRs, PR review threads). The workflow picks up the mention, spins up a fresh `ubuntu-latest` runner, gives Claude the full context (diff, files, comments), and lets it act.

## ⚠️ Important Notes

- 🔒 **This workflow won't take effect until this PR is merged.**
- 💬 **`@claude` mentions won't work until after the merge is complete.**
- 🤝 The workflow runs automatically whenever Claude is mentioned in PR or issue comments.
- 📂 Claude gets access to the entire PR or issue context (files, diffs, previous comments).

## 🔐 Security

| | |
|---|---|
| 🔑 API key | Stored as the `ANTHROPIC_API_KEY` GitHub Actions secret — never exposed in logs |
| 👥 Access control | Only users with **write** access to the repo can trigger the workflow |
| 📜 Auditability | Every Claude run shows up in the Actions run history |
| 🛠️ Tool surface | Default tools: read/write files in the repo + comments, branches, commits |
| ➕ Extending | Add more allowed tools in the workflow file: |

```yaml
claude_args: |
  --allowedTools "Bash(uv sync),Bash(uv run pytest:*),Bash(uv run pre-commit:*)"
```

See the [Claude Code action docs](https://github.com/anthropics/claude-code-action) for the full list.

## ✅ After merging

Try it out — mention `@claude` in a comment on any open PR or issue and watch the workflow fire. A good first request:

> @claude summarize the changes in this PR and call out anything that looks risky.

---

<div align="center">

🤖 _PR description authored with [Claude Code](https://claude.com/claude-code)_

</div>