### PR TITLE
fix(tests): drop stale references to removed research_memory + use_fallback

### DIFF
--- a/tests/test_inmemory_transport.py
+++ b/tests/test_inmemory_transport.py
@@ -25,7 +25,7 @@ def app():
 
 
 async def test_tools_list_matches_registered(app):
-    """All 10 tools must be discoverable via the MCP protocol."""
+    """All 9 tools must be discoverable via the MCP protocol."""
     from fastmcp import Client
 
     async with Client(app) as client:
@@ -42,7 +42,6 @@ async def test_tools_list_matches_registered(app):
         "news_aggregation",
         "github_search",
         "document_analysis",
-        "research_memory",
     }
     assert names == expected, f"tool set drift: missing={expected - names} extra={names - expected}"
 
@@ -93,19 +92,3 @@ async def test_tool_schemas_exclude_injected_ctx(app):
         assert "ctx" not in props, f"{tool.name} leaks ctx into its schema"
 
 
-async def test_research_memory_list_sessions(app):
-    """research_memory is the lowest-side-effect tool — a list call proves
-    dispatch + middleware + response rendering all work end-to-end."""
-    from fastmcp import Client
-
-    async with Client(app) as client:
-        result = await client.call_tool(
-            "research_memory",
-            {"operation": "list"},
-        )
-
-    # The tool returns markdown; just prove we got a non-empty response
-    # back through the full middleware stack without an error.
-    text = result.content[0].text if result.content else ""
-    assert isinstance(text, str)
-    assert len(text) > 0

--- a/tests/test_inmemory_transport.py
+++ b/tests/test_inmemory_transport.py
@@ -90,5 +90,3 @@ async def test_tool_schemas_exclude_injected_ctx(app):
     for tool in tools:
         props = (tool.inputSchema or {}).get("properties", {}) or {}
         assert "ctx" not in props, f"{tool.name} leaks ctx into its schema"
-
-

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -64,15 +64,13 @@ async def test_multi_search_extract_content_flag():
 
 
 async def test_multi_search_use_fallback():
-    """Test multi_search with fallback enabled/disabled."""
+    """Test multi_search end-to-end with a representative query."""
     async with create_client() as client:
-        # Test with fallback enabled (default)
         result = await client.call_tool(
             "web_search",
             {
                 "query": "artificial intelligence",
                 "num_results": 5,
-                "use_fallback": True,
                 "extract_content": False,
             },
         )


### PR DESCRIPTION
## Summary
Three tests on `main` reference features that were intentionally removed in earlier refactors. CI has been red as a result. This PR aligns the tests with current behavior — no production code changes.

## What changed and why

| Test | Why it was failing | Fix |
|---|---|---|
| `test_tools_list_matches_registered` | Expected set still listed `research_memory` | Removed `research_memory` from the expected set (now 9 tools, not 10) |
| `test_research_memory_list_sessions` | Called the deleted `research_memory` tool | Removed entirely — the surviving in-memory tests already exercise dispatch + middleware + response rendering end-to-end |
| `test_multi_search_use_fallback` | Passed deleted `use_fallback=True` kwarg to `web_search` | Dropped the kwarg; the test still exercises a representative multi-result query |

The removals were deliberate, not regressions:
- `9ea2b17` — *\"Remove research_memory tool and src/core/memory module (stateless server)\"*
- `8ef1a68` — *\"strip httpx, html_structure, dead params/methods\"*

Per `tests/CLAUDE.md` the default is to fix the tool not the test — but that rule applies when the tool is still meant to exist. Both features are gone by design.

## Verified locally
```
uv run pytest tests/test_inmemory_transport.py tests/tools/test_web_search.py --tb=short
... 9 passed in 31.85s
```

## Test plan
- [ ] CI green on this PR
- [ ] Merge unblocks subsequent main builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)