### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/rival_search_mcp/core/search/engines/__init__.py
+++ b/rival_search_mcp/core/search/engines/__init__.py
@@ -4,6 +4,7 @@ Contains implementations for various search engines.
 """
 
 from .duckduckgo.duckduckgo_engine import DuckDuckGoSearchEngine
+from .serpbase.serpbase_engine import SerpBaseSearchEngine
 from .yahoo.yahoo_engine import YahooSearchEngine
 
-__all__ = ["DuckDuckGoSearchEngine", "YahooSearchEngine"]
+__all__ = ["DuckDuckGoSearchEngine", "SerpBaseSearchEngine", "YahooSearchEngine"]

--- a/rival_search_mcp/core/search/engines/serpbase/__init__.py
+++ b/rival_search_mcp/core/search/engines/serpbase/__init__.py
@@ -1,0 +1,5 @@
+"""SerpBase (Google) search engine via REST API."""
+
+from .serpbase_engine import SerpBaseSearchEngine
+
+__all__ = ["SerpBaseSearchEngine"]

--- a/rival_search_mcp/core/search/engines/serpbase/serpbase_engine.py
+++ b/rival_search_mcp/core/search/engines/serpbase/serpbase_engine.py
@@ -1,0 +1,115 @@
+"""
+SerpBase search engine — Google Search Results API.
+
+SerpBase is a hosted API that returns structured Google search results
+as JSON. Unlike the scraping-based engines (Bing, DuckDuckGo, Yahoo)
+that parse HTML SERPs with Scrapling, this engine is purely API-driven:
+a single HTTP GET, no selectors, no TLS fingerprinting required.
+
+Requires SERPBASE_API_KEY environment variable.
+See https://serpbase.dev/dashboard/api-keys to get a key.
+"""
+
+import os
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from rival_search_mcp.logging.logger import logger
+
+from ...core.multi_engines import BaseSearchEngine, MultiSearchResult
+
+
+class SerpBaseSearchEngine(BaseSearchEngine):
+    """Google search via SerpBase REST API — no scraping, just JSON."""
+
+    API_URL = "https://api.serpbase.dev/google/search"
+
+    def __init__(self):
+        super().__init__("Google", "https://serpbase.dev")
+        self.api_key = os.environ.get("SERPBASE_API_KEY", "")
+
+    async def search(
+        self,
+        query: str,
+        num_results: int = 10,
+        extract_content: bool = True,
+        follow_links: bool = True,
+        max_depth: int = 2,
+    ) -> List[MultiSearchResult]:
+        """Search Google via SerpBase API.
+
+        If SERPBASE_API_KEY is not set, logs a warning and returns
+        an empty result list — other engines continue unaffected.
+        """
+        if not self.api_key:
+            logger.warning(
+                "SERPBASE_API_KEY not set — skipping SerpBase (Google) search. "
+                "Get a key at https://serpbase.dev/dashboard/api-keys"
+            )
+            return []
+
+        logger.info("Starting SerpBase (Google) search for: %s", query)
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(
+                    self.API_URL,
+                    params={
+                        "q": query,
+                        "num": min(num_results, 20),
+                        "api_key": self.api_key,
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as e:
+            logger.error("SerpBase API error %s: %s", e.response.status_code, e.response.text[:200])
+            return []
+        except Exception as e:
+            logger.error("SerpBase request failed: %s", e)
+            return []
+
+        results: List[MultiSearchResult] = []
+
+        organic = data.get("organic_results", [])
+        if not organic:
+            logger.info("SerpBase returned 0 organic results for: %s", query)
+            return results
+
+        for item in organic[:num_results]:
+            position = item.get("position", len(results) + 1)
+            title = (item.get("title") or "").strip()
+            link = (item.get("link") or "").strip()
+            snippet = (item.get("snippet") or "").strip()
+
+            if not title or not link:
+                continue
+
+            result = MultiSearchResult(
+                title=title,
+                url=link,
+                description=snippet,
+                engine=self.name,
+                position=position,
+                timestamp=datetime.now().isoformat(),
+            )
+
+            # Content extraction — same pattern as other engines
+            if extract_content:
+                result.real_url = link  # API links are direct, no redirect
+                content = await self._fetch_page_content(link)
+                if content:
+                    result.full_content = self._extract_main_content(content)
+                    result.internal_links = self._extract_internal_links(content, link)
+
+                    if follow_links and result.internal_links and max_depth > 1:
+                        result.second_level_content = await self._extract_second_level_content(
+                            link, result.internal_links
+                        )
+
+            results.append(result)
+
+        logger.info("SerpBase returned %d results", len(results))
+        return results

--- a/rival_search_mcp/tools/multi_search.py
+++ b/rival_search_mcp/tools/multi_search.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from rival_search_mcp.core.search.engines.bing.bing_engine import BingSearchEngine
 from rival_search_mcp.core.search.engines.duckduckgo.duckduckgo_engine import DuckDuckGoSearchEngine
 from rival_search_mcp.core.search.engines.mojeek.mojeek_engine import MojeekSearchEngine
+from rival_search_mcp.core.search.engines.serpbase.serpbase_engine import SerpBaseSearchEngine
 from rival_search_mcp.core.search.engines.wikipedia.wikipedia_engine import WikipediaSearchEngine
 from rival_search_mcp.core.search.engines.yahoo.yahoo_engine import YahooSearchEngine
 from rival_search_mcp.logging.logger import logger
@@ -19,17 +20,18 @@ from rival_search_mcp.utils.markdown_formatter import format_multi_search_markdo
 
 
 class MultiSearchOrchestrator:
-    """Orchestrates concurrent searches across five engines."""
+    """Orchestrates concurrent searches across six engines."""
 
     def __init__(self):
         self.engines = {
             "duckduckgo": DuckDuckGoSearchEngine(),
+            "google": SerpBaseSearchEngine(),
             "bing": BingSearchEngine(),
             "yahoo": YahooSearchEngine(),
             "mojeek": MojeekSearchEngine(),
             "wikipedia": WikipediaSearchEngine(),
         }
-        self.engine_order = ["duckduckgo", "bing", "yahoo", "mojeek", "wikipedia"]
+        self.engine_order = ["duckduckgo", "google", "bing", "yahoo", "mojeek", "wikipedia"]
 
     async def search_all_engines(
         self,

--- a/rival_search_mcp/tools/search.py
+++ b/rival_search_mcp/tools/search.py
@@ -1,6 +1,6 @@
 """
 Search tools for FastMCP server.
-Registers web_search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia.
+Registers web_search across DuckDuckGo, Google (SerpBase), Bing, Yahoo, Mojeek, and Wikipedia.
 """
 
 from typing import Annotated
@@ -14,28 +14,31 @@ from rival_search_mcp.tools.multi_search import web_search
 def register_search_tools(mcp: FastMCP):
     """Register all search-related tools."""
 
-    # No Google search tool - removed as requested
+    # Google search is now supported via SerpBase API engine.
+    # Set SERPBASE_API_KEY env var to enable it.
 
     @mcp.tool(
         name="web_search",
         description=(
-            "Concurrent multi-engine web search across DuckDuckGo, Bing, "
+            "Concurrent multi-engine web search across DuckDuckGo, Google (SerpBase), Bing, "
             "Yahoo, Mojeek, and Wikipedia. Results are deduplicated and "
-            "merged; failures on any single engine do not block the others."
+            "merged; failures on any single engine do not block the others. "
+            "Google results require SERPBASE_API_KEY environment variable."
         ),
         tags={
             "search",
             "web",
             "duckduckgo",
+            "google",
             "bing",
             "yahoo",
             "mojeek",
             "wikipedia",
         },
         meta={
-            "version": "2.0",
+            "version": "2.1",
             "category": "Search",
-            "engines": ["duckduckgo", "bing", "yahoo", "mojeek", "wikipedia"],
+            "engines": ["duckduckgo", "google", "bing", "yahoo", "mojeek", "wikipedia"],
         },
         annotations={
             "title": "Web Search",
@@ -44,7 +47,7 @@ def register_search_tools(mcp: FastMCP):
             "destructiveHint": False,
             "idempotentHint": False,
         },
-        # 5 engines concurrent + optional per-result content fetch.
+        # 6 engines concurrent + optional per-result content fetch.
         timeout=90.0,
     )
     async def web_search_tool(
@@ -69,8 +72,8 @@ def register_search_tools(mcp: FastMCP):
         ] = 2,
     ) -> str:
         """
-        Multi-engine search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia
-        with input sanitization and rate-limit protection.
+        Multi-engine search across DuckDuckGo, Google (SerpBase), Bing, Yahoo,
+        Mojeek, and Wikipedia with input sanitization and rate-limit protection.
         """
         from rival_search_mcp.core.security.security import InputValidator
 


### PR DESCRIPTION
## Summary

Adds **SerpBase** as a Google search engine to RivalSearchMCP — the first pure-API engine (no scraping). Complements the existing 5 engines with actual Google results.

## Background

RivalSearchMCP already has a great multi-engine architecture with DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia. But there's a conspicuous gap: the comment `# No Google search tool - removed as requested`. Google results are what many users actually want, and the existing engines can't fill that gap because they index differently.

SerpBase ([serpbase.dev](https://serpbase.dev)) is a hosted Google Search Results API — you send a query, you get structured JSON back with organic results, no scraping maintenance required. At $0.30/1k queries with 100 free searches, it's priced for casual use.

## Changes

- **New**: `rival_search_mcp/core/search/engines/serpbase/` — `SerpBaseSearchEngine` subclassing `BaseSearchEngine`
  - Pure `httpx` API call to `api.serpbase.dev/google/search`
  - Parses structured JSON → `MultiSearchResult` objects (no HTML selectors, no TLS fingerprinting)
  - Gracefully skips when `SERPBASE_API_KEY` is not set (logs a warning, returns empty — other engines continue unaffected)
- **Updated**: `rival_search_mcp/tools/multi_search.py` — added `"google": SerpBaseSearchEngine()` to orchestrator
- **Updated**: `rival_search_mcp/tools/search.py` — description/tags/meta now list 6 engines (was 5)
- **Updated**: `rival_search_mcp/core/search/engines/__init__.py` — exports `SerpBaseSearchEngine`

## Design decisions

| Decision | Rationale |
|----------|-----------|
| API key via env var (`SERPBASE_API_KEY`) | Follows existing convention (OpenRouter uses `OPENROUTER_API_KEY`); no config file changes needed |
| Graceful skip when key is missing | Matches the existing "failures on any single engine do not block the others" philosophy |
| Named `"google"` in the orchestrator | Semantically correct — it returns Google results, engine name is implementation detail |
| No Scrapling dependency | SerpBase is a JSON API, not an HTML page — simpler and more reliable |

## Testing

- When `SERPBASE_API_KEY` is set: engine returns structured Google results
- When unset: engine logs a warning and returns `[]`, web_search continues with 5 remaining engines
- Existing tests pass without modification (they don't hardcode engine names)

## Related

- Closes #49 (Feature Request: Re-add Google search via serpbase.dev)
