### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 RivalSearchMCP is a FastMCP 3.x server exposing **9 specialized tools** that search, fetch, score, and compare information across:
 
 - **5 web search engines** (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) — concurrent, deduplicated, with TLS-fingerprint-safe fetches via Scrapling
+- **Optional You.com Search provider** — add one more engine with `ENABLE_YOUCOM_SEARCH=true`
 - **9 social platforms** (Reddit, Hacker News, Stack Overflow, Dev.to, Medium, Product Hunt, Bluesky, Lobste.rs, Lemmy) — no authentication
 - **5 news sources** (Google News, Bing News, The Guardian, GDELT, DuckDuckGo News) — with time-range filtering
 - **5 academic databases** (OpenAlex, CrossRef, arXiv, PubMed, Europe PMC) + **4 dataset hubs** (Kaggle, HuggingFace, Dataverse, Zenodo)
@@ -115,6 +116,16 @@ fastmcp run server.py --transport http --port 8000
 # Run with MCP Inspector for testing
 fastmcp dev server.py
 ```
+
+### Optional You.com Search Provider
+
+Enable the You.com adapter without changing the default engine fanout:
+
+```bash
+ENABLE_YOUCOM_SEARCH=true uv run python server.py
+```
+
+If you want authenticated access, set `YDC_API_KEY` alongside the toggle. When the toggle is off, RivalSearchMCP keeps using the built-in five engines only.
 
 **Method 4: Manual UV Setup**
 ```bash
@@ -314,6 +325,7 @@ skills/rival-search-mcp/
 ## ⚡ Key Features
 
 - **Multi-Engine Search**: 5 search engines (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) with TLS-fingerprint-safe fetches via Scrapling
+- **Optional You.com Engine**: add `ENABLE_YOUCOM_SEARCH=true` to include the You.com Search API without changing defaults
 - **9-Platform Social Research**: Reddit, Hacker News, Stack Overflow, Dev.to, Medium, Product Hunt, Bluesky, Lobste.rs, Lemmy
 - **5-Source News Aggregation**: Google News, Bing News, The Guardian, GDELT, DuckDuckGo News — with time-range filtering
 - **5 Academic Databases + 4 Dataset Hubs**: OpenAlex, CrossRef, arXiv, PubMed, Europe PMC + Kaggle, HuggingFace, Dataverse, Zenodo

--- a/rival_search_mcp/core/search/__init__.py
+++ b/rival_search_mcp/core/search/__init__.py
@@ -9,10 +9,12 @@ and for any caller that wants direct access to a single engine.
 
 from .core import BaseSearchEngine, MultiSearchResult
 from .engines import DuckDuckGoSearchEngine, YahooSearchEngine
+from .engines import YouComSearchEngine
 
 __all__ = [
     "BaseSearchEngine",
     "MultiSearchResult",
     "DuckDuckGoSearchEngine",
     "YahooSearchEngine",
+    "YouComSearchEngine",
 ]

--- a/rival_search_mcp/core/search/engines/__init__.py
+++ b/rival_search_mcp/core/search/engines/__init__.py
@@ -4,6 +4,7 @@ Contains implementations for various search engines.
 """
 
 from .duckduckgo.duckduckgo_engine import DuckDuckGoSearchEngine
+from .youcom.youcom_engine import YouComSearchEngine
 from .yahoo.yahoo_engine import YahooSearchEngine
 
-__all__ = ["DuckDuckGoSearchEngine", "YahooSearchEngine"]
+__all__ = ["DuckDuckGoSearchEngine", "YahooSearchEngine", "YouComSearchEngine"]

--- a/rival_search_mcp/core/search/engines/youcom/__init__.py
+++ b/rival_search_mcp/core/search/engines/youcom/__init__.py
@@ -1,0 +1,5 @@
+"""You.com search engine adapter."""
+
+from .youcom_engine import YouComSearchEngine
+
+__all__ = ["YouComSearchEngine"]

--- a/rival_search_mcp/core/search/engines/youcom/youcom_engine.py
+++ b/rival_search_mcp/core/search/engines/youcom/youcom_engine.py
@@ -1,0 +1,217 @@
+"""
+You.com search engine implementation for RivalSearchMCP.
+
+The adapter is opt-in so the default multi-engine fanout remains unchanged.
+When enabled, it talks to the public You.com Search API and maps results into
+the same MultiSearchResult shape used by the built-in engines.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from rival_search_mcp.logging.logger import logger
+
+from ...core.multi_engines import BaseSearchEngine, MultiSearchResult
+
+
+class YouComSearchEngine(BaseSearchEngine):
+    """You.com Search API adapter."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        super().__init__("You.com", "https://api.you.com")
+        self.search_url = "https://api.you.com/v1/agents/search"
+        self.api_key = (api_key or os.getenv("YDC_API_KEY", "")).strip()
+        self.user_agent = "youdotcom-integration/damionrashford-rivalsearchmcp"
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def search(
+        self,
+        query: str,
+        num_results: int = 10,
+        extract_content: bool = True,
+        follow_links: bool = True,
+        max_depth: int = 2,
+    ) -> List[MultiSearchResult]:
+        """Search You.com and optionally fetch result pages."""
+        logger.info("Starting You.com search for: %s", query)
+
+        payload = {
+            "query": query,
+            "count": max(1, min(num_results, 20)),
+        }
+
+        response = await self._post_json(payload)
+        if response is None:
+            return []
+
+        results = self._parse_results(response, limit=num_results)
+        logger.info("You.com returned %d results", len(results))
+
+        if extract_content and results:
+            for result in results:
+                result.real_url = self._extract_real_url(result.url)
+                target_url = result.real_url if result.real_url != result.url else result.url
+                if not target_url:
+                    continue
+
+                content = await self._fetch_page_content(target_url)
+                if not content:
+                    continue
+
+                result.full_content = self._extract_main_content(content)
+                result.internal_links = self._extract_internal_links(content, target_url)
+
+                if follow_links and result.internal_links and max_depth > 1:
+                    result.second_level_content = await self._extract_second_level_content(
+                        target_url, result.internal_links
+                    )
+
+        return results
+
+    async def _post_json(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Call the You.com Search API and return decoded JSON."""
+        client = await self._get_client()
+        try:
+            response = await client.post(self.search_url, json=payload)
+        except Exception as exc:
+            logger.warning("You.com fetch failed: %s", exc)
+            return None
+
+        if response.status_code != 200:
+            logger.warning(
+                "You.com returned %s for %r (body snippet: %s)",
+                response.status_code,
+                payload.get("query", ""),
+                response.text[:200],
+            )
+            return None
+
+        try:
+            data = response.json()
+        except Exception as exc:
+            logger.warning("You.com returned invalid JSON: %s", exc)
+            return None
+
+        if not isinstance(data, dict):
+            logger.warning("You.com response was not a JSON object")
+            return None
+
+        return data
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Create a reusable client with the attribution header."""
+        if self._client is None:
+            headers = {
+                "User-Agent": self.user_agent,
+                "Accept": "application/json",
+            }
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+
+            self._client = httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                headers=headers,
+            )
+
+        return self._client
+
+    def _parse_results(
+        self, payload: Dict[str, Any], limit: int = 10
+    ) -> List[MultiSearchResult]:
+        """Map the API response into the shared search result shape."""
+        items = self._find_items(payload)
+        results: List[MultiSearchResult] = []
+
+        for index, item in enumerate(items[:limit]):
+            if not isinstance(item, dict):
+                continue
+
+            title = self._first_text(
+                item,
+                ["title", "name", "headline", "document_title", "result_title"],
+            )
+            url = self._first_text(
+                item,
+                ["url", "link", "href", "targetUrl", "target_url", "destination"],
+            )
+            description = self._first_text(
+                item,
+                ["description", "snippet", "summary", "text", "body", "excerpt"],
+            )
+
+            if not title and url:
+                title = url
+            if not title or not url:
+                continue
+
+            results.append(
+                MultiSearchResult(
+                    title=title,
+                    url=url,
+                    description=description,
+                    engine=self.name,
+                    position=index + 1,
+                    timestamp=datetime.now().isoformat(),
+                )
+            )
+
+        return results
+
+    def _find_items(self, payload: Dict[str, Any]) -> List[Any]:
+        """Find the first list of result objects in the response payload."""
+        candidate_paths = [
+            ("results",),
+            ("hits",),
+            ("items",),
+            ("documents",),
+            ("data", "results"),
+            ("data", "hits"),
+            ("data", "items"),
+            ("response", "results"),
+            ("response", "hits"),
+            ("response", "items"),
+        ]
+
+        for path in candidate_paths:
+            node: Any = payload
+            for key in path:
+                if not isinstance(node, dict):
+                    node = None
+                    break
+                node = node.get(key)
+
+            if isinstance(node, list):
+                return node
+
+            if isinstance(node, dict):
+                for nested_key in ("results", "hits", "items", "documents"):
+                    nested = node.get(nested_key)
+                    if isinstance(nested, list):
+                        return nested
+
+        return []
+
+    def _first_text(self, item: Dict[str, Any], keys: List[str]) -> str:
+        """Return the first non-empty string value for the given keys."""
+        for key in keys:
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            if isinstance(value, dict):
+                for nested_key in ("text", "value", "content", "url"):
+                    nested = value.get(nested_key)
+                    if isinstance(nested, str) and nested.strip():
+                        return nested.strip()
+        return ""
+
+    async def close(self):
+        """Close the shared You.com HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None

--- a/rival_search_mcp/server.py
+++ b/rival_search_mcp/server.py
@@ -45,7 +45,8 @@ all results as equal.
 
 Search (every result auto-annotated with a `quality` block + an
 aggregate `confidence` summary — high / medium / low):
-- web_search: DuckDuckGo + Bing + Yahoo + Mojeek + Wikipedia (no auth)
+- web_search: DuckDuckGo + Bing + Yahoo + Mojeek + Wikipedia (no auth;
+  optional You.com Search API provider when ENABLE_YOUCOM_SEARCH=true)
 - social_search: Reddit, Hacker News, Dev.to, Product Hunt, Medium,
                  Stack Overflow, Bluesky, Lobste.rs, Lemmy (no auth)
 - news_aggregation: Google News, Bing News, Guardian, GDELT, DuckDuckGo

--- a/rival_search_mcp/tools/multi_search.py
+++ b/rival_search_mcp/tools/multi_search.py
@@ -4,6 +4,7 @@ Provides comprehensive search across multiple engines with fallback support.
 """
 
 import asyncio
+import os
 from datetime import datetime
 from typing import Any, Dict
 
@@ -14,12 +15,13 @@ from rival_search_mcp.core.search.engines.duckduckgo.duckduckgo_engine import Du
 from rival_search_mcp.core.search.engines.mojeek.mojeek_engine import MojeekSearchEngine
 from rival_search_mcp.core.search.engines.wikipedia.wikipedia_engine import WikipediaSearchEngine
 from rival_search_mcp.core.search.engines.yahoo.yahoo_engine import YahooSearchEngine
+from rival_search_mcp.core.search.engines.youcom.youcom_engine import YouComSearchEngine
 from rival_search_mcp.logging.logger import logger
 from rival_search_mcp.utils.markdown_formatter import format_multi_search_markdown
 
 
 class MultiSearchOrchestrator:
-    """Orchestrates concurrent searches across five engines."""
+    """Orchestrates concurrent searches across the configured engines."""
 
     def __init__(self):
         self.engines = {
@@ -29,7 +31,10 @@ class MultiSearchOrchestrator:
             "mojeek": MojeekSearchEngine(),
             "wikipedia": WikipediaSearchEngine(),
         }
-        self.engine_order = ["duckduckgo", "bing", "yahoo", "mojeek", "wikipedia"]
+        if _env_flag("ENABLE_YOUCOM_SEARCH"):
+            self.engines["youcom"] = YouComSearchEngine()
+            logger.info("You.com search engine enabled via ENABLE_YOUCOM_SEARCH")
+        self.engine_order = list(self.engines.keys())
 
     async def search_all_engines(
         self,
@@ -163,6 +168,11 @@ def get_orchestrator() -> MultiSearchOrchestrator:
     if _orchestrator is None:
         _orchestrator = MultiSearchOrchestrator()
     return _orchestrator
+
+
+def _env_flag(name: str) -> bool:
+    """Return True when the named environment variable is set to a truthy value."""
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 async def web_search(

--- a/rival_search_mcp/tools/search.py
+++ b/rival_search_mcp/tools/search.py
@@ -20,8 +20,9 @@ def register_search_tools(mcp: FastMCP):
         name="web_search",
         description=(
             "Concurrent multi-engine web search across DuckDuckGo, Bing, "
-            "Yahoo, Mojeek, and Wikipedia. Results are deduplicated and "
-            "merged; failures on any single engine do not block the others."
+            "Yahoo, Mojeek, and Wikipedia. An optional You.com provider can "
+            "be enabled with ENABLE_YOUCOM_SEARCH. Results are deduplicated "
+            "and merged; failures on any single engine do not block the others."
         ),
         tags={
             "search",

--- a/tests/tools/test_youcom_search.py
+++ b/tests/tools/test_youcom_search.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the optional You.com search integration.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from rival_search_mcp.core.search.engines.youcom.youcom_engine import YouComSearchEngine
+from rival_search_mcp.tools.multi_search import MultiSearchOrchestrator
+
+
+def test_youcom_parser_maps_common_result_shapes():
+    engine = YouComSearchEngine(api_key="test-key")
+    payload = {
+        "results": [
+            {
+                "title": "You.com result",
+                "url": "https://example.com/you",
+                "snippet": "A short summary",
+            },
+            {
+                "name": "Nested result",
+                "link": "https://example.com/nested",
+                "description": "Nested summary",
+            },
+        ]
+    }
+
+    results = engine._parse_results(payload, limit=10)
+
+    assert len(results) == 2
+    assert results[0].engine == "You.com"
+    assert results[0].title == "You.com result"
+    assert results[0].url == "https://example.com/you"
+    assert results[0].description == "A short summary"
+    assert results[1].title == "Nested result"
+    assert results[1].url == "https://example.com/nested"
+
+
+async def test_youcom_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("ENABLE_YOUCOM_SEARCH", raising=False)
+
+    orchestrator = MultiSearchOrchestrator()
+
+    assert "youcom" not in orchestrator.engines
+    await orchestrator.close_all_engines()
+
+
+async def test_youcom_is_enabled_when_flagged(monkeypatch):
+    monkeypatch.setenv("ENABLE_YOUCOM_SEARCH", "true")
+
+    orchestrator = MultiSearchOrchestrator()
+
+    assert "youcom" in orchestrator.engines
+    assert isinstance(orchestrator.engines["youcom"], YouComSearchEngine)
+    await orchestrator.close_all_engines()
+
+
+if __name__ == "__main__":
+    test_youcom_parser_maps_common_result_shapes()
+    print("✅ You.com parser test passed")


### PR DESCRIPTION
## Why this is useful
RivalSearchMCP already fans out across several search engines. Adding You.com as an opt-in engine gives callers one more high-signal web search source without changing the default behavior for existing users.

## What changed
- Added a `YouComSearchEngine` adapter for `https://api.you.com/v1/agents/search`
- Wired the engine into `web_search` behind `ENABLE_YOUCOM_SEARCH`
- Kept the default five-engine fanout unchanged unless the toggle is set
- Documented the toggle in the README and server instructions
- Added unit tests for the result parser and for opt-in engine registration

## Setup
Optional env vars:
- `ENABLE_YOUCOM_SEARCH=true`
- `YDC_API_KEY` for authenticated access, if you have one

Example:
```bash
ENABLE_YOUCOM_SEARCH=true YDC_API_KEY=... uv run python server.py
```

## Usage
Once enabled, `web_search` includes the You.com provider alongside the existing engines. If the API call fails or the response is empty, the other engines still run and the request still completes.

## Validation
- `python3 -m py_compile` on the touched Python files
- `uv run pytest tests/tools/test_youcom_search.py -q`
- `uv run pytest tests/tools/test_web_search.py -q`
- `uv run ruff check` on the touched Python files

## Fallback/error handling
- If `ENABLE_YOUCOM_SEARCH` is not set, the new engine is not registered
- If You.com returns an error or invalid JSON, the engine returns no results and the other engines continue
- If `YDC_API_KEY` is unset, the adapter still stays optional and uses the keyless path

Tracking issue: https://github.com/youdotcom-oss/integration-tracking/issues/155
