### PR TITLE
docs: add FAQ entry on cross-session memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ Yes. Clone the repo, run `uv sync --extra dev`, then `fastmcp run` (stdio) or `f
 Deliberately. The server returns deterministic, auditable output so the caller's model can reason over it — a consistent machine can't hallucinate the way a synthesizing one can. If you want an autonomous agent loop, run it in your client.
 </details>
 
+<details>
+<summary><strong>Does RivalSearchMCP remember past research across sessions?</strong></summary>
+
+No, and that is intentional here too. Every call is stateless and deterministic, which is what keeps results reproducible and auditable in the first place. If the calling agent needs to carry findings forward into a later session, that is a job for a separate memory layer rather than something a research tool should own. One option that keeps the same local and auditable philosophy is Vestige, a local first MCP memory server the calling agent can write findings into and recall from later. Disclosure: I maintain Vestige.
+</details>
+
 ## 🤝 Contributing
 
 Contributions are welcome! Whether it's fixing bugs, adding new research tools, or improving documentation, your help is appreciated.


### PR DESCRIPTION
## What this adds

One new FAQ entry, right after the existing "Why is there no in-server LLM" answer, since it's the natural follow-up question. It notes that the stateless, deterministic design is intentional here too, and that carrying findings across sessions is a job for a separate memory layer rather than something a research tool should take on.

## Disclosure

I maintain Vestige, the memory server named as one option in the new entry. I'm not proposing any code change or dependency, just a documentation note for anyone who hits this exact question, since RivalSearchMCP is deliberately stateless by design and someone building a longer-running agent on top of it will want to know where session memory is supposed to live.

Happy to adjust wording, trim it, or drop the specific mention entirely and just answer the question generically if you'd rather keep the FAQ vendor-neutral. Either way felt worth raising given how clean the "why no in-server LLM" answer already is.