### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 RivalSearchMCP is a FastMCP 3.x server exposing **9 specialized tools** that search, fetch, score, and compare information across:
 
-- **5 web search engines** (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) — concurrent, deduplicated, with TLS-fingerprint-safe fetches via Scrapling
+- **5 web search engines** (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) plus optional You.com via `YDC_API_KEY` — concurrent, deduplicated, with TLS-fingerprint-safe fetches via Scrapling
 - **9 social platforms** (Reddit, Hacker News, Stack Overflow, Dev.to, Medium, Product Hunt, Bluesky, Lobste.rs, Lemmy) — no authentication
 - **5 news sources** (Google News, Bing News, The Guardian, GDELT, DuckDuckGo News) — with time-range filtering
 - **5 academic databases** (OpenAlex, CrossRef, arXiv, PubMed, Europe PMC) + **4 dataset hubs** (Kaggle, HuggingFace, Dataverse, Zenodo)
@@ -142,7 +142,7 @@ uv sync
 Every tool carries `ToolAnnotations` (`readOnlyHint`, `openWorldHint`, `destructiveHint`, `idempotentHint`) so MCP clients like Claude and ChatGPT can skip confirmation prompts where safe. Every tool has a `timeout=` ceiling so a hung source can't stall the client.
 
 ### Search & Discovery (5 tools)
-- **`web_search`** — concurrent multi-engine search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia. Scrapling-backed TLS fingerprinting bypasses Cloudflare/Akamai fronting. Per-engine failures don't block the others.
+- **`web_search`** — concurrent multi-engine search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia, with optional You.com when `YDC_API_KEY` is configured. Scrapling-backed TLS fingerprinting bypasses Cloudflare/Akamai fronting. Per-engine failures don't block the others.
 - **`social_search`** — 9 platforms: Reddit, Hacker News, Stack Overflow, Dev.to, Medium, Product Hunt, Bluesky, Lobste.rs, Lemmy. No authentication.
 - **`news_aggregation`** — 5 sources: Google News, Bing News, The Guardian, GDELT, DuckDuckGo News. Accepts `time_range` (day/week/month/anytime).
 - **`github_search`** — repository search with built-in rate limiting (60/hr unauthenticated), optional README inclusion.
@@ -313,7 +313,7 @@ skills/rival-search-mcp/
 
 ## ⚡ Key Features
 
-- **Multi-Engine Search**: 5 search engines (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) with TLS-fingerprint-safe fetches via Scrapling
+- **Multi-Engine Search**: 5 search engines (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia) with optional You.com via `YDC_API_KEY`, and TLS-fingerprint-safe fetches via Scrapling
 - **9-Platform Social Research**: Reddit, Hacker News, Stack Overflow, Dev.to, Medium, Product Hunt, Bluesky, Lobste.rs, Lemmy
 - **5-Source News Aggregation**: Google News, Bing News, The Guardian, GDELT, DuckDuckGo News — with time-range filtering
 - **5 Academic Databases + 4 Dataset Hubs**: OpenAlex, CrossRef, arXiv, PubMed, Europe PMC + Kaggle, HuggingFace, Dataverse, Zenodo
@@ -358,6 +358,12 @@ Deliberately. The server returns deterministic, auditable output so the caller's
 </details>
 
 ## 🤝 Contributing
+
+### Optional You.com search
+
+Set `YDC_API_KEY` to enable You.com as an additional search engine in
+`web_search`. If the key is absent, RivalSearchMCP keeps its original
+zero-key search behavior.
 
 Contributions are welcome! Whether it's fixing bugs, adding new research tools, or improving documentation, your help is appreciated.
 

--- a/rival_search_mcp/core/search/__init__.py
+++ b/rival_search_mcp/core/search/__init__.py
@@ -8,11 +8,12 @@ and for any caller that wants direct access to a single engine.
 """
 
 from .core import BaseSearchEngine, MultiSearchResult
-from .engines import DuckDuckGoSearchEngine, YahooSearchEngine
+from .engines import DuckDuckGoSearchEngine, YahooSearchEngine, YouComSearchEngine
 
 __all__ = [
     "BaseSearchEngine",
     "MultiSearchResult",
     "DuckDuckGoSearchEngine",
     "YahooSearchEngine",
+    "YouComSearchEngine",
 ]

--- a/rival_search_mcp/core/search/core/multi_engines.py
+++ b/rival_search_mcp/core/search/core/multi_engines.py
@@ -65,6 +65,10 @@ class BaseSearchEngine:
         self.base_url = base_url
         self.visited_urls: Set[str] = set()
 
+    def is_configured(self) -> bool:
+        """Whether this engine should participate in the search pool."""
+        return True
+
     async def search(
         self,
         query: str,

--- a/rival_search_mcp/core/search/engines/__init__.py
+++ b/rival_search_mcp/core/search/engines/__init__.py
@@ -5,5 +5,6 @@ Contains implementations for various search engines.
 
 from .duckduckgo.duckduckgo_engine import DuckDuckGoSearchEngine
 from .yahoo.yahoo_engine import YahooSearchEngine
+from .youcom.youcom_engine import YouComSearchEngine
 
-__all__ = ["DuckDuckGoSearchEngine", "YahooSearchEngine"]
+__all__ = ["DuckDuckGoSearchEngine", "YahooSearchEngine", "YouComSearchEngine"]

--- a/rival_search_mcp/core/search/engines/youcom/__init__.py
+++ b/rival_search_mcp/core/search/engines/youcom/__init__.py
@@ -1,0 +1,5 @@
+"""You.com search engine package."""
+
+from .youcom_engine import YouComSearchEngine
+
+__all__ = ["YouComSearchEngine"]

--- a/rival_search_mcp/core/search/engines/youcom/youcom_engine.py
+++ b/rival_search_mcp/core/search/engines/youcom/youcom_engine.py
@@ -1,0 +1,132 @@
+"""
+You.com search engine implementation for RivalSearchMCP.
+
+You.com is opt-in through YDC_API_KEY so the default zero-key behavior
+stays unchanged. The engine uses the direct Search API and mirrors the
+shape of the existing engine adapters.
+"""
+
+from datetime import datetime
+from typing import List
+
+import httpx
+
+from rival_search_mcp.logging.logger import logger
+
+from ...core.multi_engines import BaseSearchEngine, MultiSearchResult
+
+SEARCH_ENDPOINT = "https://ydc-index.io/v1/search"
+DEFAULT_TIMEOUT = 30.0
+USER_AGENT = "youdotcom-integration/damionrashford-rivalsearchmcp"
+
+
+class YouComSearchEngine(BaseSearchEngine):
+    """You.com search via the direct Search API."""
+
+    def __init__(self, api_key: str):
+        api_key = api_key.strip()
+        if not api_key:
+            raise ValueError("You.com search requires a non-empty YDC_API_KEY")
+
+        super().__init__("You.com", "https://you.com")
+        self.api_key = api_key
+
+    async def search(
+        self,
+        query: str,
+        num_results: int = 10,
+        extract_content: bool = True,
+        follow_links: bool = True,
+        max_depth: int = 2,
+    ) -> List[MultiSearchResult]:
+        """Search You.com and return result cards in the common engine shape."""
+        logger.info("Starting You.com search for: %s", query)
+
+        results = await self._search_api(query, num_results)
+        logger.info("You.com returned %d results", len(results))
+
+        if extract_content and results:
+            for result in results:
+                result.real_url = self._extract_real_url(result.url)
+                target_url = result.real_url if result.real_url != result.url else result.url
+                if not target_url:
+                    continue
+
+                content = await self._fetch_page_content(target_url)
+                if not content:
+                    continue
+
+                result.full_content = self._extract_main_content(content)
+                result.internal_links = self._extract_internal_links(content, target_url)
+
+                if follow_links and result.internal_links and max_depth > 1:
+                    result.second_level_content = await self._extract_second_level_content(
+                        target_url, result.internal_links
+                    )
+
+        return results
+
+    async def _search_api(self, query: str, num_results: int) -> List[MultiSearchResult]:
+        """Query the You.com Search API and normalize the payload."""
+        params = {
+            "query": query,
+            "count": min(max(1, num_results), 50),
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+                response = await client.get(
+                    SEARCH_ENDPOINT,
+                    params=params,
+                    headers={
+                        "X-API-Key": self.api_key,
+                        "User-Agent": USER_AGENT,
+                        "Accept": "application/json",
+                    },
+                )
+        except Exception as e:
+            logger.error("You.com fetch failed: %s", e)
+            return []
+
+        if response.status_code != 200:
+            logger.warning(
+                "You.com returned %s for %r (body snippet: %s)",
+                response.status_code,
+                query,
+                response.text[:200],
+            )
+            return []
+
+        try:
+            payload = response.json()
+        except Exception as e:
+            logger.error("You.com response parsing failed: %s", e)
+            return []
+
+        results: List[MultiSearchResult] = []
+        items = list((payload.get("results") or {}).get("web") or [])
+        items.extend((payload.get("results") or {}).get("news") or [])
+
+        for i, item in enumerate(items[:num_results]):
+            url = item.get("url", "")
+            title = item.get("title") or url
+            snippets = item.get("snippets") or []
+            description = item.get("description") or (snippets[0] if snippets else "")
+            markdown = (item.get("contents") or {}).get("markdown")
+
+            if not url:
+                continue
+
+            results.append(
+                MultiSearchResult(
+                    title=title,
+                    url=url,
+                    description=description,
+                    engine=self.name,
+                    position=i + 1,
+                    timestamp=datetime.now().isoformat(),
+                    full_content=markdown,
+                )
+            )
+
+        return results

--- a/rival_search_mcp/routes/routes.py
+++ b/rival_search_mcp/routes/routes.py
@@ -166,7 +166,7 @@ def register_custom_routes(mcp):
             tools_info = {
                 "search": {
                     "web_search": {
-                        "description": "Multi-engine web search (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia)",
+                        "description": "Multi-engine web search (DuckDuckGo, Bing, Yahoo, Mojeek, Wikipedia, optional You.com when YDC_API_KEY is set)",
                         "parameters": ["query", "num_results", "search_type"],
                     },
                     "social_search": {

--- a/rival_search_mcp/server.py
+++ b/rival_search_mcp/server.py
@@ -45,7 +45,8 @@ all results as equal.
 
 Search (every result auto-annotated with a `quality` block + an
 aggregate `confidence` summary — high / medium / low):
-- web_search: DuckDuckGo + Bing + Yahoo + Mojeek + Wikipedia (no auth)
+- web_search: DuckDuckGo + Bing + Yahoo + Mojeek + Wikipedia, with
+  optional You.com when `YDC_API_KEY` is set
 - social_search: Reddit, Hacker News, Dev.to, Product Hunt, Medium,
                  Stack Overflow, Bluesky, Lobste.rs, Lemmy (no auth)
 - news_aggregation: Google News, Bing News, Guardian, GDELT, DuckDuckGo

--- a/rival_search_mcp/tools/multi_search.py
+++ b/rival_search_mcp/tools/multi_search.py
@@ -4,6 +4,7 @@ Provides comprehensive search across multiple engines with fallback support.
 """
 
 import asyncio
+import os
 from datetime import datetime
 from typing import Any, Dict
 
@@ -14,6 +15,7 @@ from rival_search_mcp.core.search.engines.duckduckgo.duckduckgo_engine import Du
 from rival_search_mcp.core.search.engines.mojeek.mojeek_engine import MojeekSearchEngine
 from rival_search_mcp.core.search.engines.wikipedia.wikipedia_engine import WikipediaSearchEngine
 from rival_search_mcp.core.search.engines.yahoo.yahoo_engine import YahooSearchEngine
+from rival_search_mcp.core.search.engines.youcom.youcom_engine import YouComSearchEngine
 from rival_search_mcp.logging.logger import logger
 from rival_search_mcp.utils.markdown_formatter import format_multi_search_markdown
 
@@ -30,6 +32,11 @@ class MultiSearchOrchestrator:
             "wikipedia": WikipediaSearchEngine(),
         }
         self.engine_order = ["duckduckgo", "bing", "yahoo", "mojeek", "wikipedia"]
+
+        ydc_api_key = os.getenv("YDC_API_KEY", "").strip()
+        if ydc_api_key:
+            self.engines["youcom"] = YouComSearchEngine(ydc_api_key)
+            self.engine_order.append("youcom")
 
     async def search_all_engines(
         self,

--- a/rival_search_mcp/tools/search.py
+++ b/rival_search_mcp/tools/search.py
@@ -1,6 +1,7 @@
 """
 Search tools for FastMCP server.
-Registers web_search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia.
+Registers web_search across DuckDuckGo, Bing, Yahoo, Mojeek, and
+Wikipedia, with optional You.com support when configured.
 """
 
 from typing import Annotated
@@ -20,7 +21,8 @@ def register_search_tools(mcp: FastMCP):
         name="web_search",
         description=(
             "Concurrent multi-engine web search across DuckDuckGo, Bing, "
-            "Yahoo, Mojeek, and Wikipedia. Results are deduplicated and "
+            "Yahoo, Mojeek, and Wikipedia, with optional You.com support "
+            "when YDC_API_KEY is configured. Results are deduplicated and "
             "merged; failures on any single engine do not block the others."
         ),
         tags={
@@ -31,11 +33,19 @@ def register_search_tools(mcp: FastMCP):
             "yahoo",
             "mojeek",
             "wikipedia",
+            "youcom",
         },
         meta={
             "version": "2.0",
             "category": "Search",
-            "engines": ["duckduckgo", "bing", "yahoo", "mojeek", "wikipedia"],
+            "engines": [
+                "duckduckgo",
+                "bing",
+                "yahoo",
+                "mojeek",
+                "wikipedia",
+                "youcom",
+            ],
         },
         annotations={
             "title": "Web Search",
@@ -69,8 +79,9 @@ def register_search_tools(mcp: FastMCP):
         ] = 2,
     ) -> str:
         """
-        Multi-engine search across DuckDuckGo, Bing, Yahoo, Mojeek, and Wikipedia
-        with input sanitization and rate-limit protection.
+        Multi-engine search across DuckDuckGo, Bing, Yahoo, Mojeek, and
+        Wikipedia, with optional You.com support when configured, plus
+        input sanitization and rate-limit protection.
         """
         from rival_search_mcp.core.security.security import InputValidator
 

--- a/tests/test_multi_search_youcom.py
+++ b/tests/test_multi_search_youcom.py
@@ -1,0 +1,21 @@
+"""
+Tests for optional You.com registration in the multi-search orchestrator.
+"""
+
+from rival_search_mcp.tools.multi_search import MultiSearchOrchestrator
+
+
+def test_youcom_engine_is_disabled_without_env(monkeypatch):
+    monkeypatch.delenv("YDC_API_KEY", raising=False)
+
+    orchestrator = MultiSearchOrchestrator()
+
+    assert "youcom" not in orchestrator.engines
+
+
+def test_youcom_engine_is_enabled_with_env(monkeypatch):
+    monkeypatch.setenv("YDC_API_KEY", "ydc-test-key")
+
+    orchestrator = MultiSearchOrchestrator()
+
+    assert "youcom" in orchestrator.engines

--- a/tests/test_youcom_engine.py
+++ b/tests/test_youcom_engine.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for the optional You.com search engine.
+"""
+
+import pytest
+
+from rival_search_mcp.core.search.core.multi_engines import MultiSearchResult
+from rival_search_mcp.core.search.engines.youcom.youcom_engine import YouComSearchEngine
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    last_request = None
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get(self, url, params=None, headers=None):
+        _FakeClient.last_request = {
+            "url": url,
+            "params": params,
+            "headers": headers,
+        }
+        return _FakeResponse(
+            200,
+            payload={
+                "results": {
+                    "web": [
+                        {
+                            "url": "https://example.com/agent",
+                            "title": "Agent Search",
+                            "description": "Search for agent tools",
+                            "snippets": ["Snippet text"],
+                            "contents": {"markdown": "# Agent Search"},
+                        }
+                    ],
+                    "news": [
+                        {
+                            "url": "https://example.com/news",
+                            "title": "Agent News",
+                            "snippets": ["News snippet"],
+                        }
+                    ],
+                }
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_youcom_search_maps_results_and_sends_standard_headers(monkeypatch):
+    monkeypatch.setattr(
+        "rival_search_mcp.core.search.engines.youcom.youcom_engine.httpx.AsyncClient",
+        _FakeClient,
+    )
+
+    engine = YouComSearchEngine(api_key="ydc-test-key")
+    results = await engine.search(
+        query="agent search",
+        num_results=2,
+        extract_content=False,
+    )
+
+    assert _FakeClient.last_request is not None
+    assert _FakeClient.last_request["url"] == "https://ydc-index.io/v1/search"
+    assert _FakeClient.last_request["params"] == {"query": "agent search", "count": 2}
+    assert _FakeClient.last_request["headers"] == {
+        "X-API-Key": "ydc-test-key",
+        "User-Agent": "youdotcom-integration/damionrashford-rivalsearchmcp",
+        "Accept": "application/json",
+    }
+
+    assert len(results) == 2
+    first, second = results
+
+    assert isinstance(first, MultiSearchResult)
+    assert first.title == "Agent Search"
+    assert first.url == "https://example.com/agent"
+    assert first.description == "Search for agent tools"
+    assert first.engine == "You.com"
+    assert first.position == 1
+    assert first.full_content == "# Agent Search"
+    assert first.timestamp
+
+    assert second.title == "Agent News"
+    assert second.url == "https://example.com/news"
+    assert second.description == "News snippet"
+    assert second.engine == "You.com"
+    assert second.position == 2
+    assert second.timestamp
+
+
+def test_youcom_search_requires_api_key():
+    with pytest.raises(ValueError, match="YDC_API_KEY"):
+        YouComSearchEngine(api_key="   ")


### PR DESCRIPTION
This keeps You.com search optional and fits the existing multi-engine search stack.

What changed:
- Added a `YouComSearchEngine` that calls the direct You.com Search API.
- Wired it into `web_search` only when `YDC_API_KEY` is set.
- Updated the tool metadata, server instructions, and docs to mention the optional engine.
- Added unit coverage for the You.com request mapping and the opt-in gate.

Setup:
- Set `YDC_API_KEY` to enable the new engine.
- Leave it unset and the server keeps its current zero-key behavior.

Usage:
- With `YDC_API_KEY` configured, `web_search` will query You.com alongside the existing engines and merge the results into the same response format.

Fallback/error handling:
- If `YDC_API_KEY` is absent, You.com is not added to the search pool.
- If You.com returns an error, that engine fails independently and the rest of the search fan-out still runs.

Validation:
- `uv run pytest tests/test_youcom_engine.py tests/test_multi_search_youcom.py -q`
- `uv run pytest tests/test_inmemory_transport.py -q`
- `uv run pytest tests/tools/test_web_search.py -q`
- `uv run ruff check rival_search_mcp tests/test_youcom_engine.py tests/test_multi_search_youcom.py`

Tracking:
- https://github.com/youdotcom-oss/integration-tracking/issues/220
