### PR TITLE
deps: bump protego to 0.6.2 (GHSA-wjmf-p669-5m5p)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -227,7 +227,7 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-protego==0.6.0
+protego==0.6.2
     # via scrapling
 py-key-value-aio==0.4.4
     # via fastmcp

--- a/uv.lock
+++ b/uv.lock
@@ -2727,11 +2727,11 @@ wheels = [
 
 [[package]]
 name = "protego"
-version = "0.6.0"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/a7/955c422611d00a6e4a06d30b367ea9bb4fb09d48552e92aef1ba312493c7/protego-0.6.0.tar.gz", hash = "sha256:3466f41438421cf90008e98534d5fde47dc16a17482571d021143ac18b70ace9", size = 3137423, upload-time = "2026-01-29T10:58:28.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/8c/f4dd590f48addf31398f78a78962eaa99eb4c87ac09c1927497032644731/protego-0.6.0-py3-none-any.whl", hash = "sha256:7210e6e06a8db839502baf1bfbcb810689a58e394d31408ef1ef9e4e3d79fc44", size = 10313, upload-time = "2026-01-29T10:58:26.748Z" },
+    { url = "https://files.pythonhosted.org/packages/61/10/cbd3c06603bb8b3e0e871df24ee793a6e3b53d8c4cc8763f1b8b936649aa/protego-0.6.2-py3-none-any.whl", hash = "sha256:714de21d82527c9be900066c3211b266985dd6a19b6e70c57e033fc1a589f3ff", size = 10296, upload-time = "2026-06-25T09:33:14.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates `protego` to address GHSA-wjmf-p669-5m5p (CVE-2026-55520, ReDoS in robots.txt wildcard matching).

Evidence:
- `requirements.txt` pinned `protego==0.6.0`, also locked in `uv.lock`
- osv-scanner reported GHSA-wjmf-p669-5m5p for protego 0.6.0 before the update
- updated version: `0.6.2`

Validation:
- osv-scanner no longer reports GHSA-wjmf-p669-5m5p after the update
- `uv lock --check` passes with the surgical lock entry update
- `uv run pytest` passes (70 passed; 2 pre-existing failures in tests/tools/test_social_search.py also fail on main without this change, they hit live reddit/bluesky endpoints)

Scope: dependency/lockfile update only.
